### PR TITLE
Fix certbot `CryptographyDeprecationWarning`

### DIFF
--- a/docker-compose.ssl.yaml
+++ b/docker-compose.ssl.yaml
@@ -13,7 +13,7 @@ services:
       - "80:80"
       - "443:443"
   certbot:
-    image: certbot/certbot:latest
+    image: certbot/certbot:v3.0.1
     container_name: certbot
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - moodle
   certbot:
-    image: certbot/certbot:latest
+    image: certbot/certbot:v3.0.1
     container_name: certbot
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw


### PR DESCRIPTION
Fix certbot `CryptographyDeprecationWarning` by pinning certbot version to 3.0.1.

ref: https://github.com/certbot/certbot/issues/9967